### PR TITLE
fix doc

### DIFF
--- a/labs/provision-federation-controller-manager.md
+++ b/labs/provision-federation-controller-manager.md
@@ -57,8 +57,11 @@ kubectl config set-context federation-cluster \
 Switch to the `federation-cluster` context and dump the federated API server credentials:
 
 ```
-kubectl --context=federation-cluster \
-  config view --flatten --minify > kubeconfigs/federation-apiserver/kubeconfig
+kubectl config use-context federation-apiserver
+```
+
+```
+kubectl  config view --flatten --minify > kubeconfigs/federation-apiserver/kubeconfig
 ```
 
 #### Create the Federated API Server Secret

--- a/labs/provision-federation-controller-manager.md
+++ b/labs/provision-federation-controller-manager.md
@@ -57,7 +57,7 @@ kubectl config set-context federation-cluster \
 Switch to the `federation-cluster` context and dump the federated API server credentials:
 
 ```
-kubectl config use-context federation-apiserver
+kubectl config use-context federation-cluster
 ```
 
 ```


### PR DESCRIPTION
kubectl config doesn't respect --context flag. For that reason, federation-cluster/kubeconfig was wrong and got a certificate issue.

this workaround close https://github.com/kelseyhightower/kubernetes-cluster-federation/issues/17
