### PR TITLE
update hyperkube image version from 1.4.0 to 1.5.2 in api-server and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,4 @@ The federated control plane must run in a Kubernetes host cluster which has acce
 * [Delete Federated Cluster](labs/cleaning-up.md)
 
 
-## Geo testing
-`https://www.geopeeker.com/`
-`https://github.com/debianmaster/federated-ingress-sample`
+

--- a/README.md
+++ b/README.md
@@ -47,3 +47,8 @@ The federated control plane must run in a Kubernetes host cluster which has acce
 ## Cleaning Up
 
 * [Delete Federated Cluster](labs/cleaning-up.md)
+
+
+## Geo testing
+`https://www.geopeeker.com/`
+`https://github.com/debianmaster/federated-ingress-sample`

--- a/deployments/federation-apiserver.yaml
+++ b/deployments/federation-apiserver.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: apiserver
-        image: gcr.io/google_containers/hyperkube-amd64:v1.4.0
+        image: gcr.io/google_containers/hyperkube-amd64:v1.5.2
         command:
           - /hyperkube
           - federation-apiserver

--- a/deployments/federation-controller-manager.yaml
+++ b/deployments/federation-controller-manager.yaml
@@ -19,7 +19,7 @@ spec:
           path: /etc/ssl
       containers:
       - name: controller-manager
-        image: gcr.io/google_containers/hyperkube-amd64:v1.4.0
+        image: gcr.io/google_containers/hyperkube-amd64:v1.5.2
         args:
           - /hyperkube
           - federation-controller-manager


### PR DESCRIPTION
while  creating configmaps on a cluster created using this example,  we found that hyperkube version was old and not accepting new features like configmaps.    i had changed the hyperkube version to latest stable.