### PR TITLE
Moving nginx service to type: LoadBalancer, updating labels/selectors…

### DIFF
--- a/services/nginx.yaml
+++ b/services/nginx.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    run: nginx
+    app: nginx
   name: nginx
 spec:
   ports:
@@ -10,7 +10,6 @@ spec:
     protocol: TCP
     targetPort: 80
     name: http
-    nodePort: 32110
   selector:
-    run: nginx
-  type: NodePort
+    app: nginx
+  type: LoadBalancer


### PR DESCRIPTION
…, and removing nodePort

Ran through the new labs (👍👍 way up) but found that the type and labels/selector of the nginx service were not matching the updated labs / nginx deployment. Updated them and finished the labs with a working Federation. 

PR patches the service file up. 