### PR TITLE
Switch .local domain TLD to .localdomain

### DIFF
--- a/labs/02-cluster-dns-managed-zone.md
+++ b/labs/02-cluster-dns-managed-zone.md
@@ -9,5 +9,5 @@ The follow command will create a DNS zone named `federation`. In a production se
 ```
 gcloud dns managed-zones create federation \
   --description "Kubernetes federation testing" \
-  --dns-name federation.local
+  --dns-name federation.localdomain
 ```


### PR DESCRIPTION
I noticed while running through the tutorial that Google DNS thinks .local is a normal TLD and requires proof of ownership (which obviously can't be given). Using .localdomain instead works fine.

Awesome tutorial. :+1: 