### PR TITLE
Update readme to indicate this is 'the hard way'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Kubernetes Cluster Federation Tutorial
+# Kubernetes Cluster Federation (The Hard Way)
 
 This tutorial will walk you through setting up a Kubernetes cluster federation composed of four Kubernetes clusters across multiple GCP regions.
+
+This guide is not for people looking for a fully automated command to bring up a Kubernetes cluster federation. If that's you then check out [Setting up Cluster Federation with Kubefed](https://kubernetes.io/docs/tutorials/federation/set-up-cluster-federation-kubefed/).
+
+This tutorial is optimized for learning, which means taking the long route to help people understand each task required to bootstrap a Kubernetes cluster federation. This tutorial requires access to [Google Compute Engine](https://cloud.google.com/compute).
 
 ## Prerequisites
 


### PR DESCRIPTION
This page has high google-juice for 'kubernetes cluster federation'.  It's incredibly useful to have as a learning resource but now we have `kubefed` on the way, it's not necessarily the first way that someone should solve this problem.

The Kubernetes The Hard Way tutorial makes this distinction very clearly, so I've lifted some of its readme and modified it to fit here.