### PR TITLE
Update to cluster v1.6.2

### DIFF
--- a/labs/01-cluster-bootstrap.md
+++ b/labs/01-cluster-bootstrap.md
@@ -17,7 +17,7 @@ Create the `asia-east1-b` cluster:
 
 ```
 gcloud beta container clusters create asia-east1-b \
-  --cluster-version 1.6.1 \
+  --cluster-version 1.6.2 \
   --zone asia-east1-b \
   --scopes "cloud-platform,storage-ro,logging-write,monitoring-write,service-control,service-management,https://www.googleapis.com/auth/ndev.clouddns.readwrite"
 ```
@@ -26,7 +26,7 @@ Create the `europe-west1-b` cluster:
 
 ```
 gcloud beta container clusters create europe-west1-b \
-  --cluster-version 1.6.1 \
+  --cluster-version 1.6.2 \
   --zone=europe-west1-b \
   --scopes "cloud-platform,storage-ro,logging-write,monitoring-write,service-control,service-management,https://www.googleapis.com/auth/ndev.clouddns.readwrite"
 ```
@@ -35,7 +35,7 @@ Create the `us-east1-b` cluster:
 
 ```
 gcloud beta container clusters create us-east1-b \
-  --cluster-version 1.6.1 \
+  --cluster-version 1.6.2 \
   --zone=us-east1-b \
   --scopes "cloud-platform,storage-ro,logging-write,monitoring-write,service-control,service-management,https://www.googleapis.com/auth/ndev.clouddns.readwrite"
 ```
@@ -44,7 +44,7 @@ Create the `us-central1-b` cluster:
 
 ```
 gcloud beta container clusters create us-central1-b \
-  --cluster-version 1.6.1 \
+  --cluster-version 1.6.2 \
   --zone=us-central1-b \
   --scopes "cloud-platform,storage-ro,logging-write,monitoring-write,service-control,service-management,https://www.googleapis.com/auth/ndev.clouddns.readwrite"
 ```
@@ -96,8 +96,8 @@ gcloud container clusters list
 
 ```
 NAME            ZONE            MASTER_VERSION  MASTER_IP        MACHINE_TYPE   NODE_VERSION  NUM_NODES  STATUS
-asia-east1-b    asia-east1-b    1.6.1           XXX.XXX.XXX.XXX  n1-standard-1  1.6.1         3          RUNNING
-europe-west1-b  europe-west1-b  1.6.1           XXX.XXX.XX.X     n1-standard-1  1.6.1         3          RUNNING
-us-central1-b   us-central1-b   1.6.1           XXX.XXX.XXX.XX   n1-standard-1  1.6.1         3          RUNNING
-us-east1-b      us-east1-b      1.6.1           XXX.XXX.XXX.XX   n1-standard-1  1.6.1         3          RUNNING
+asia-east1-b    asia-east1-b    1.6.2           XXX.XXX.XXX.XXX  n1-standard-1  1.6.2         3          RUNNING
+europe-west1-b  europe-west1-b  1.6.2           XXX.XXX.XX.X     n1-standard-1  1.6.2         3          RUNNING
+us-central1-b   us-central1-b   1.6.2           XXX.XXX.XXX.XX   n1-standard-1  1.6.2         3          RUNNING
+us-east1-b      us-east1-b      1.6.2           XXX.XXX.XXX.XX   n1-standard-1  1.6.2         3          RUNNING
 ```

--- a/labs/03-download-an-updated-kubectl-client.md
+++ b/labs/03-download-an-updated-kubectl-client.md
@@ -4,7 +4,7 @@ This guide will walk you through downloading an updated kubectl client. kubectl 
 
 ### Darwin
 ```
-curl -O https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/darwin/amd64/kubectl
+curl -O https://storage.googleapis.com/kubernetes-release/release/v1.6.2/bin/darwin/amd64/kubectl
 chmod a+x kubectl
 sudo cp kubectl /usr/local/bin/kubectl
 ```
@@ -12,7 +12,7 @@ sudo cp kubectl /usr/local/bin/kubectl
 ### Linux
 
 ```
-curl -O https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/linux/amd64/kubectl
+curl -O https://storage.googleapis.com/kubernetes-release/release/v1.6.2/bin/linux/amd64/kubectl
 chmod a+x kubectl
 sudo cp kubectl /usr/local/bin/kubectl
 ```


### PR DESCRIPTION
Creating container clusters with v1.6.1 returns an error:
```
gcloud beta container clusters create europe-west1-b --cluster-version 1.6.1 --zone=europe-west1-b --scopes "cloud-platform,storage-ro,logging-write,monitoring-write,service-control,service-management,https://www.googleapis.com/auth/ndev.clouddns.readwrite"
ERROR: (gcloud.beta.container.clusters.create) ResponseError: code=400, message=Version is invalid.
```
Update to version 1.6.2