### PR TITLE
Change svc type to NodePort.

### DIFF
--- a/services/nginx.yaml
+++ b/services/nginx.yaml
@@ -12,4 +12,4 @@ spec:
     name: http
   selector:
     app: nginx
-  type: LoadBalancer
+  type: NodePort


### PR DESCRIPTION
As per conversations in #sig-federation and [this blog post](https://medium.com/google-cloud/planet-scale-microservices-with-cluster-federation-and-global-load-balancing-on-kubernetes-and-cd182f981653), type NodePort is recommended for federated services on GCP. Tested with cluster v1.6.2